### PR TITLE
make database branch-aware

### DIFF
--- a/src/database.py
+++ b/src/database.py
@@ -5,14 +5,14 @@ def get_repo_list(cnx):
   # pick all repos with status of 0
   cur = cnx.cursor()
   cur.execute("SELECT `repo` FROM `github_deploy_repo` WHERE `status` = 0")
-  repos = [repo.split('/') for (repo,) in cur]
+  repos = [repo.split('/', 2) for (repo,) in cur]
   cur.close()
   return repos
 
 
-def set_repo_status(cnx, owner, name, commit, status):
+def set_repo_status(cnx, owner, name, branch, commit, status):
   # update the repo status table
-  repo = '%s/%s' % (owner, name)
+  repo = '%s/%s/%s' % (owner, name, branch)
   cur = cnx.cursor()
 
   # execute the proper update

--- a/src/ddl/github_deploy_repo.sql
+++ b/src/ddl/github_deploy_repo.sql
@@ -12,7 +12,7 @@
 - `id`
   unique identifier for each record
 - `repo`
-  the name of the github repo (in the form of "owner/name")
+  the name of the github repo (in the form of "owner/name/branch")
 - `commit`
   hash of the latest commit
 - `datetime`

--- a/src/web/badge.php
+++ b/src/web/badge.php
@@ -5,7 +5,7 @@ generates a "badge" for github repos (based on http://shield.io)
 initial version by dfarrow on 2016-10-20
 
 test like:
-  curl http://delphi.midas.cs.cmu.edu/~automation/public/github_deploy_repo/badge.php?repo=cmu-delphi/www-nowcast
+  curl http://delphi.midas.cs.cmu.edu/~automation/public/github_deploy_repo/badge.php?repo=cmu-delphi/www-nowcast/master
 */
 
 // conveniently reuse automation's database "library"
@@ -14,6 +14,11 @@ $dbh = DatabaseConnect();
 
 // the data is in the query string
 $repo = $_GET['repo'];
+
+// default to branch master
+if (substr_count($repo, '/') === 1) {
+  $repo .= '/master';
+}
 
 // trust no one
 $repo = mysql_real_escape_string($repo);


### PR DESCRIPTION
- store branch along with owner/repo
- queries updated to use branch names
- webhook extracts branch, if available (e.g. there is not branch for a 
tag update event)
- badge rendering is unchanged, but to support existing URLs, branch 
defaults to 'master' when unspecified