### PR TITLE
Support recursive copying

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,7 @@ Additional fields:
 
 - `src` (**required**)
 
-    The source file. If this ends with `*`, such as `public/*`, and `match` is
-    present, recursively match all files in this directory.
+    The source file.
 
 - `dst` (**required**)
 
@@ -116,6 +115,13 @@ Additional fields:
     Replace template strings in source file with values found in the list of
     template files. Each file is a JSON object containing a list of (key,
     value) pairs to be replaced.
+
+- `recursive` (_optional_)
+
+    If set to true (false by default), `src` and `dst` are treated as
+    directories. `match` must be specified, and all matching files are copied,
+    including subdirectories.
+
 
 ## `move`
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ Additional fields:
 
 - `src` (**required**)
 
-    The source file.
+    The source file. If this ends with `*`, such as `public/*`, and `match` is
+    present, recursively match all files in this directory.
 
 - `dst` (**required**)
 

--- a/src/actions/copymove.py
+++ b/src/actions/copymove.py
@@ -137,7 +137,7 @@ def copymove(repo_link, commit, path, row, substitutions):
   # determine which file(s) should be used
   if 'match' in row:
     sources, destinations = [], []
-    for name in glob.glob(os.path.join(src[0], '*', recursive=True)):
+    for name in glob.glob(os.path.join(src[0], '*'), recursive=True):
       src2 = file_operations.get_file(name)
       basename = src2[2]
       if re.match(row['match'], basename) is not None:

--- a/src/actions/copymove.py
+++ b/src/actions/copymove.py
@@ -137,9 +137,15 @@ def copymove(repo_link, commit, path, row, substitutions):
   # determine which file(s) should be used
   if 'match' in row:
     sources, destinations = [], []
-    for name in glob.glob(os.path.join(src[0], '*'), recursive=True):
+    recursive = row.get("recursive", False)
+
+    glob_path = "**" if recursive else "*"
+
+    for name in glob.glob(os.path.join(src[0], glob_path),
+                          recursive=recursive):
       src2 = file_operations.get_file(name)
-      basename = src2[2]
+      basename = os.path.relpath(src2[0], start=src[0])
+
       if re.match(row['match'], basename) is not None:
         sources.append(src2)
         file_path = os.path.join(dst[0], basename)

--- a/src/actions/copymove.py
+++ b/src/actions/copymove.py
@@ -137,7 +137,7 @@ def copymove(repo_link, commit, path, row, substitutions):
   # determine which file(s) should be used
   if 'match' in row:
     sources, destinations = [], []
-    for name in glob.glob(os.path.join(src[0], '*')):
+    for name in glob.glob(os.path.join(src[0], '*', recursive=True)):
       src2 = file_operations.get_file(name)
       basename = src2[2]
       if re.match(row['match'], basename) is not None:


### PR DESCRIPTION
This is just a simple trick: `glob` can match recursively if it sees `**`, and we already append one `*` to the path, so now recursion is automatically supported if the user-specified path ends in a single `*`. Otherwise the behavior should be identical.